### PR TITLE
Remove event payload dump to log.

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -53,9 +53,7 @@ describe('action', () => {
     await main.run()
 
     expect(runMock).toHaveReturned()
-    expect(infoMock).toHaveBeenCalledWith(
-      'Nothing to install.'
-    )
+    expect(infoMock).toHaveBeenCalledWith('Nothing to install.')
   })
 
   it('sets a failed status', async () => {

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -44,7 +44,7 @@ describe('action', () => {
     })
   })
 
-  it('logs the event payload', async () => {
+  it('logs if nothing to do', async () => {
     // Mock the action's payload
     github.context.payload = {
       actor: 'mona'
@@ -54,7 +54,7 @@ describe('action', () => {
 
     expect(runMock).toHaveReturned()
     expect(infoMock).toHaveBeenCalledWith(
-      `The event payload: ${JSON.stringify(github.context.payload, null, 2)}`
+      'Nothing to install.'
     )
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -89348,11 +89348,6 @@ async function run() {
     const cachePackages = core.getInput('cache-packages')
 
     await pipxInstall({ installConfigFile, cachePackages })
-
-    // Output the payload for debugging
-    core.info(
-      `The event payload: ${JSON.stringify(github.context.payload, null, 2)}`
-    )
   } catch (error) {
     // Fail the workflow step if an error occurs
     core.setFailed(error.message)

--- a/src/main.js
+++ b/src/main.js
@@ -12,11 +12,6 @@ async function run() {
     const cachePackages = core.getInput('cache-packages')
 
     await pipxInstall({ installConfigFile, cachePackages })
-
-    // Output the payload for debugging
-    core.info(
-      `The event payload: ${JSON.stringify(github.context.payload, null, 2)}`
-    )
   } catch (error) {
     // Fail the workflow step if an error occurs
     core.setFailed(error.message)


### PR DESCRIPTION
Resolves #32
This logging message was leftover from the initial boilerpate.  It is unnecessary.